### PR TITLE
finished past exhibition page + added images on sanity studio

### DIFF
--- a/nextjs-new_website/src/app/think_round_fine_arts/past_exhibitions/[slug]/page.tsx
+++ b/nextjs-new_website/src/app/think_round_fine_arts/past_exhibitions/[slug]/page.tsx
@@ -1,10 +1,10 @@
 import { client, urlFor } from "@/sanity/client";
-import Image from "next/image";
 import Link from "next/link";
 import { PortableText, PortableTextBlock } from "next-sanity";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import ExhibitionGallery from "@/components/ExhibitionGallery";
+import ArtistCard from "@/components/ArtistCard";
 import type { Metadata } from "next";
 
 export const revalidate = 30;
@@ -288,36 +288,16 @@ export default async function PastExhibitionDetailPage({
               </h2>
               <div className="flex gap-4 overflow-x-auto pb-3 scrollbar-hide">
                 {exhibition.artists.map((artist, index) => (
-                  <div
+                  <ArtistCard
                     key={index}
-                    className="flex-shrink-0 flex items-center gap-3 bg-gray-50 rounded-lg px-4 py-3 border border-gray-200 min-w-[240px] max-w-[300px]"
-                  >
-                    {artist.photo && (
-                      <div className="flex-shrink-0 w-12 h-12 rounded-full overflow-hidden">
-                        <Image
-                          src={urlFor(artist.photo)
-                            .width(96)
-                            .height(96)
-                            .url()}
-                          alt={`${artist.name} portrait`}
-                          width={96}
-                          height={96}
-                          className="object-cover w-full h-full"
-                          sizes="48px"
-                        />
-                      </div>
-                    )}
-                    <div className="min-w-0">
-                      <h3 className="text-sm font-semibold text-black truncate">
-                        {artist.name}
-                      </h3>
-                      {artist.bio && (
-                        <p className="text-xs text-gray-500 line-clamp-2 leading-relaxed">
-                          {artist.bio}
-                        </p>
-                      )}
-                    </div>
-                  </div>
+                    name={artist.name}
+                    bio={artist.bio}
+                    photoUrl={
+                      artist.photo
+                        ? urlFor(artist.photo).width(96).height(96).url()
+                        : undefined
+                    }
+                  />
                 ))}
               </div>
             </section>

--- a/nextjs-new_website/src/components/ArtistCard.tsx
+++ b/nextjs-new_website/src/components/ArtistCard.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import { X } from "lucide-react";
+
+interface ArtistCardProps {
+  name: string;
+  bio?: string;
+  photoUrl?: string;
+}
+
+export default function ArtistCard({ name, bio, photoUrl }: ArtistCardProps) {
+  const [open, setOpen] = useState(false);
+  const hasBio = Boolean(bio && bio.trim().length > 0);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open]);
+
+  const cardContent = (
+    <>
+      {photoUrl && (
+        <div className="flex-shrink-0 w-12 h-12 rounded-full overflow-hidden">
+          <Image
+            src={photoUrl}
+            alt={`${name} portrait`}
+            width={96}
+            height={96}
+            className="object-cover w-full h-full"
+            sizes="48px"
+          />
+        </div>
+      )}
+      <div className="min-w-0 text-left">
+        <h3 className="text-sm font-semibold text-black truncate">{name}</h3>
+        {hasBio && (
+          <p className="text-xs text-gray-500 line-clamp-2 leading-relaxed">
+            {bio}
+          </p>
+        )}
+      </div>
+    </>
+  );
+
+  const cardClasses =
+    "flex-shrink-0 flex items-center gap-3 bg-gray-50 rounded-lg px-4 py-3 border border-gray-200 min-w-[240px] max-w-[300px]";
+
+  return (
+    <>
+      {hasBio ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className={`${cardClasses} text-left cursor-pointer hover:bg-gray-100 hover:border-gray-300 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-black`}
+          aria-label={`Read bio for ${name}`}
+        >
+          {cardContent}
+        </button>
+      ) : (
+        <div className={cardClasses}>{cardContent}</div>
+      )}
+
+      {open && hasBio && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="artist-bio-title"
+          onClick={() => setOpen(false)}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 py-8"
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="relative bg-white rounded-lg shadow-xl max-w-lg w-full max-h-[85vh] overflow-y-auto p-6 md:p-8"
+          >
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close"
+              className="absolute top-3 right-3 p-1 rounded-full hover:bg-gray-100 transition-colors"
+            >
+              <X className="w-5 h-5 text-gray-600" />
+            </button>
+            <h3
+              id="artist-bio-title"
+              className="text-2xl font-bold text-black mb-4 pr-8"
+            >
+              {name}
+            </h3>
+            <p className="text-base text-gray-700 leading-relaxed whitespace-pre-line">
+              {bio}
+            </p>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/nextjs-new_website/src/components/ExhibitionGallery.tsx
+++ b/nextjs-new_website/src/components/ExhibitionGallery.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import Image from "next/image";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
 
 interface GalleryImage {
   src: string;
@@ -18,6 +18,11 @@ interface ExhibitionGalleryProps {
 
 export default function ExhibitionGallery({ images }: ExhibitionGalleryProps) {
   const [activeIndex, setActiveIndex] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    setIsLoading(true);
+  }, [activeIndex]);
 
   const goNext = useCallback(() => {
     setActiveIndex((prev) => (prev + 1) % images.length);
@@ -46,13 +51,22 @@ export default function ExhibitionGallery({ images }: ExhibitionGalleryProps) {
       className="mb-12 outline-none focus-visible:outline-2 focus-visible:outline-black"
     >
       {/* Hero Image - fixed aspect ratio to prevent layout shift */}
-      <div className="relative w-full aspect-[3/2] rounded-lg overflow-hidden bg-white">
+      <div className="relative w-full aspect-[3/2] rounded-lg overflow-hidden bg-gray-50">
+        {isLoading && (
+          <div
+            className="absolute inset-0 z-20 flex items-center justify-center bg-gray-50"
+            aria-hidden="true"
+          >
+            <Loader2 className="w-10 h-10 text-gray-400 animate-spin" />
+          </div>
+        )}
         <Image
           key={activeIndex}
           src={active.src}
           alt={active.alt}
           fill
           className="object-contain"
+          onLoad={() => setIsLoading(false)}
           {...(activeIndex === 0
             ? { priority: true }
             : {

--- a/studio-new_website/schemaTypes/pastExhibition.ts
+++ b/studio-new_website/schemaTypes/pastExhibition.ts
@@ -80,10 +80,9 @@ export default defineType({
             },
             {
               name: 'caption',
-              title: 'Caption',
+              title: 'Caption (optional)',
               type: 'string',
               description: 'e.g. "Artist Name - Title, Year, Medium"',
-              validation: (Rule) => Rule.required(),
             },
             {
               name: 'alt',


### PR DESCRIPTION
This pull request introduces a new `ArtistCard` component to improve the display and interaction of artist information in past exhibition pages. It also enhances the `ExhibitionGallery` with a loading spinner for smoother user experience, and makes a minor update to the Sanity schema for past exhibitions.

**Artist display and interaction improvements:**
- Replaces the inline artist card rendering in `PastExhibitionDetailPage` with the new reusable `ArtistCard` component, which shows artist details and allows users to view full bios in a modal dialog. This improves accessibility and code maintainability.

**Exhibition gallery enhancements:**
- Adds a loading spinner to `ExhibitionGallery` while images are loading, providing better visual feedback and preventing layout shifts

**Sanity schema update:**
- Updates the `caption` field in the `pastExhibition` schema to make it optional and clarifies its label, improving content editor experience.