### PR TITLE
Add Contact Us page with Sanity CMS integration

### DIFF
--- a/nextjs-new_website/src/app/[slug]/page.tsx
+++ b/nextjs-new_website/src/app/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { PortableText, type SanityDocument } from "next-sanity";
 import imageUrlBuilder from "@sanity/image-url";
 import type { SanityImageSource } from "@sanity/image-url/lib/types/types";
 import { client } from "@/sanity/client";
+import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
@@ -21,7 +22,7 @@ export default async function PostPage({
   params: Promise<{ slug: string }>;
 }) {
   const resolvedParams = await params;
-  const slugRaw = (resolvedParams as any)?.slug ?? null;
+  const slugRaw = resolvedParams.slug;
   const slug = typeof slugRaw === "string" ? decodeURIComponent(slugRaw) : slugRaw;
 
   let post: SanityDocument | null = null;
@@ -68,12 +69,12 @@ export default async function PostPage({
         ← Back to posts
       </Link>
       {postImageUrl && (
-        <img
+        <Image
           src={postImageUrl}
           alt={post.title}
           className="aspect-video rounded-xl"
-          width="550"
-          height="310"
+          width={550}
+          height={310}
         />
       )}
       <h1 className="text-4xl font-bold mb-8">{post.title}</h1>

--- a/nextjs-new_website/src/app/about/about_us/page.tsx
+++ b/nextjs-new_website/src/app/about/about_us/page.tsx
@@ -12,13 +12,13 @@ interface AboutUs {
 interface CurrentPartner {
   _id: string;
   name: string;
-  logo: { asset: { _ref: string } };
-  hyperlink: string
+  logo?: { asset?: { _ref: string } };
+  hyperlink?: string
 }
 interface PastPartner {
   _id: string;
   name: string;
-  logo: { asset: { _ref: string } };
+  logo?: { asset?: { _ref: string } };
 }
 
 export const revalidate = 60;
@@ -53,7 +53,7 @@ async function getPastPartners(){
 }
 
 function readMarkdown(text: string){
-    var toReturn = text;
+    let toReturn = text;
     //  //Blockquote
     toReturn = toReturn.replace(/\>(.+)/g,"<blockquote>$1</blockquote>");
     //bolden
@@ -70,7 +70,7 @@ function readMarkdown(text: string){
 }
 
 function enlargeTitle(text:string){
-  var toReturn = text;
+  let toReturn = text;
   if (/\#(.+)/g.test(toReturn)){
     toReturn = toReturn.replace(/\#(.+)/g,"<div style='font-weight:bold; text-align: center; font-size:xx-large'>$1</div>");
     return (
@@ -111,15 +111,26 @@ export default async function AboutUsPage() {
               <div id="currentPartners" className="px-50">
                 {cPartners.map((partner) => (
                   <div key={partner._id}>
-                    <Link href={partner.hyperlink}>
-                    <Image
-                      src={urlFor(partner.logo).width(150).height(150).url()}
-                      alt={partner.name}
-                      width={150}
-                      height={150}
-                      className="rounded-lg object-cover"
-                    />
-                    </Link>
+                    {partner.logo?.asset && partner.hyperlink && (
+                      <Link href={partner.hyperlink}>
+                        <Image
+                          src={urlFor(partner.logo).width(150).height(150).url()}
+                          alt={partner.name}
+                          width={150}
+                          height={150}
+                          className="rounded-lg object-cover"
+                        />
+                      </Link>
+                    )}
+                    {partner.logo?.asset && !partner.hyperlink && (
+                      <Image
+                        src={urlFor(partner.logo).width(150).height(150).url()}
+                        alt={partner.name}
+                        width={150}
+                        height={150}
+                        className="rounded-lg object-cover"
+                      />
+                    )}
                   </div>
                 ))}
               </div>
@@ -128,13 +139,15 @@ export default async function AboutUsPage() {
             <div id="pastPartners" className="px-50">
               {pPartners.map((partner) => (
                 <div key={partner._id}>
-                  <Image
-                    src={urlFor(partner.logo).width(150).height(150).url()}
-                    alt={partner.name}
-                    width={150}
-                    height={150}
-                    className="block rounded-lg object-cover"
-                  />
+                  {partner.logo?.asset && (
+                    <Image
+                      src={urlFor(partner.logo).width(150).height(150).url()}
+                      alt={partner.name}
+                      width={150}
+                      height={150}
+                      className="block rounded-lg object-cover"
+                    />
+                  )}
                 </div>
               ))
               }

--- a/nextjs-new_website/src/app/about/contact_us/page.tsx
+++ b/nextjs-new_website/src/app/about/contact_us/page.tsx
@@ -1,0 +1,198 @@
+import Navbar from "@/components/Navbar";
+import { client } from "@/sanity/client";
+
+interface ContactUsData {
+  title?: string;
+  contactName?: string;
+  aboutCompany?: string;
+  address?: string;
+  phone?: string;
+  email?: string;
+  boardSectionTitle?: string;
+}
+
+interface BoardMember {
+  name: string;
+  role?: string;
+}
+
+export const revalidate = 60;
+
+const defaultBoardMembers: BoardMember[] = [
+  { name: "Heidi Hardin", role: "President" },
+  { name: "Hideki Uchida", role: "Treasurer" },
+  { name: "Kelly Campbell-Hinshaw", role: "Secretary" },
+  { name: "Ismael Biaye" },
+  { name: "Jeffrey Betcher" },
+];
+
+async function getContactPage() {
+  try {
+    const query = `*[_type == "contactUs"][0]{
+      title,
+      contactName,
+      aboutCompany,
+      address,
+      phone,
+      email,
+      boardSectionTitle
+    }`;
+    return await client.fetch<ContactUsData | null>(query);
+  } catch (error) {
+    console.error("Error fetching contact page data:", error);
+    return null;
+  }
+}
+
+async function getBoardMembers() {
+  try {
+    const query = `*[_type == "boardMember"] | order(order asc){
+      name,
+      role
+    }`;
+    return await client.fetch<BoardMember[]>(query);
+  } catch (error) {
+    console.error("Error fetching board members:", error);
+    return [];
+  }
+}
+
+function formatPhoneHref(phone: string) {
+  const digits = phone.replace(/\D/g, "");
+  return digits.length === 10 ? `+1${digits}` : `+${digits}`;
+}
+
+export default async function ContactUsPage() {
+  const contactData = await getContactPage();
+  const boardMembersFromSanity = await getBoardMembers();
+
+  const title = contactData?.title || "Contact";
+  const contactName = contactData?.contactName || "Heidi Hardin";
+  const aboutCompany =
+    contactData?.aboutCompany ||
+    "ThinkRound is a San Francisco-based nonprofit bringing together art, education, and community programs.";
+  const address =
+    contactData?.address ||
+    "2140 Bush Street, Suite 1\nSan Francisco, CA 94115\nUnited States";
+  const phone = contactData?.phone || "415-771-2198";
+  const email = contactData?.email || "heidi@heidihardin.com";
+  const boardSectionTitle =
+    contactData?.boardSectionTitle || "Meet our Board of Directors";
+  const boardMembers =
+    boardMembersFromSanity.length > 0
+      ? boardMembersFromSanity
+      : defaultBoardMembers;
+
+  return (
+    <div className="w-full min-h-screen mx-auto bg-white">
+      <Navbar />
+
+      <main className="max-w-4xl mx-auto px-4 py-12 md:py-20 text-gray-800">
+        <h1 className="text-4xl font-bold mb-10 text-center">{title}</h1>
+
+        <div className="grid gap-10 md:grid-cols-[1fr_1.1fr]">
+          <section className="space-y-8 text-lg">
+            <div>
+              <h2 className="text-2xl font-bold mb-3">About ThinkRound</h2>
+              <p className="leading-8">{aboutCompany}</p>
+            </div>
+
+            <div>
+              <h2 className="text-2xl font-bold mb-3">Address</h2>
+              <p className="leading-8 whitespace-pre-line">{address}</p>
+            </div>
+
+            <div>
+              <h2 className="text-2xl font-bold mb-3">Primary Contact</h2>
+              <p className="font-semibold">{contactName}</p>
+              <p className="mt-2">
+                Phone:{" "}
+                <a
+                  href={`tel:${formatPhoneHref(phone)}`}
+                  className="text-orange-500 hover:text-orange-600 hover:underline"
+                >
+                  {phone}
+                </a>
+              </p>
+              <p>
+                Email:{" "}
+                <a
+                  href={`mailto:${email}`}
+                  className="text-orange-500 hover:text-orange-600 hover:underline"
+                >
+                  {email}
+                </a>
+              </p>
+            </div>
+          </section>
+
+          <section className="border border-gray-200 rounded-lg p-6 shadow-sm">
+            <h2 className="text-2xl font-bold mb-6 text-center">
+              Send a Message
+            </h2>
+            <form action={`mailto:${email}`} method="post" className="space-y-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <label className="block">
+                  <span className="block text-sm font-semibold mb-2">
+                    First Name
+                  </span>
+                  <input
+                    type="text"
+                    name="firstName"
+                    required
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-orange-500 focus:outline-none"
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="block text-sm font-semibold mb-2">
+                    Last Name
+                  </span>
+                  <input
+                    type="text"
+                    name="lastName"
+                    required
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-orange-500 focus:outline-none"
+                  />
+                </label>
+              </div>
+
+              <label className="block">
+                <span className="block text-sm font-semibold mb-2">
+                  Message
+                </span>
+                <textarea
+                  name="message"
+                  required
+                  rows={6}
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-orange-500 focus:outline-none"
+                />
+              </label>
+
+              <button
+                type="submit"
+                className="w-full rounded-md bg-orange-500 px-5 py-3 font-semibold text-white transition hover:bg-orange-600"
+              >
+                Send Message
+              </button>
+            </form>
+          </section>
+        </div>
+
+        <section className="mt-12">
+          <h2 className="text-2xl font-bold mb-6 text-center">
+            {boardSectionTitle}
+          </h2>
+          <ul className="space-y-3 text-center text-lg">
+            {boardMembers.map((member) => (
+              <li key={member.name}>
+                {member.name}
+                {member.role ? `, ${member.role}` : ""}
+              </li>
+            ))}
+          </ul>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/nextjs-new_website/src/app/about/our-artists/page.tsx
+++ b/nextjs-new_website/src/app/about/our-artists/page.tsx
@@ -1,4 +1,5 @@
 import { client, urlFor } from "@/sanity/client";
+import type { SanityImageSource } from "@sanity/image-url/lib/types/types";
 import Image from "next/image";
 
 export const revalidate = 60;
@@ -6,7 +7,7 @@ export const revalidate = 60;
 type Artist = {
   _id: string;
   name: string;
-  image?: any;
+  image?: SanityImageSource;
   bio?: string;
 };
 

--- a/nextjs-new_website/src/app/blogs/[year]/[month]/[day]/[slug]/ptComponents.tsx
+++ b/nextjs-new_website/src/app/blogs/[year]/[month]/[day]/[slug]/ptComponents.tsx
@@ -1,9 +1,27 @@
 import Image from "next/image";
 import { urlFor } from "@/sanity/client";
+import type { ReactNode } from "react";
+import type { SanityImageSource } from "@sanity/image-url/lib/types/types";
+
+type PortableImageValue = SanityImageSource & {
+  alt?: string;
+  asset?: {
+    metadata?: {
+      dimensions?: {
+        width: number;
+        height: number;
+      };
+    };
+  };
+};
+
+interface PortableChildrenProps {
+  children?: ReactNode;
+}
 
 export const ptComponents = {
   types: {
-    image: ({ value }: any) => {
+    image: ({ value }: { value: PortableImageValue }) => {
       // Use natural dimensions from Sanity metadata
       const { width, height } = value.asset?.metadata?.dimensions || {
         width: 800,
@@ -23,23 +41,23 @@ export const ptComponents = {
     },
   },
   block: {
-    normal: ({ children }: any) => (
+    normal: ({ children }: PortableChildrenProps) => (
       <p className="text-justify text-lg font-light text-gray-800 mb-8 leading-relaxed">
         {children}
       </p>
     ),
 
-    h1: ({ children }: any) => (
+    h1: ({ children }: PortableChildrenProps) => (
       <h1 className="text-5xl uppercase tracking-wide text-gray-800 mt-20 mb-10 text-left">
         {children}
       </h1>
     ),
-    h2: ({ children }: any) => (
+    h2: ({ children }: PortableChildrenProps) => (
       <h2 className="text-6xl uppercase tracking-wide text-gray-800 mt-16 mb-8 text-left">
         {children}
       </h2>
     ),
-    h3: ({ children }: any) => (
+    h3: ({ children }: PortableChildrenProps) => (
       <h3 className="text-4xl uppercase tracking-wide text-gray-800 mt-14 mb-6 text-left">
         {children}
       </h3>

--- a/nextjs-new_website/src/app/donate/page.tsx
+++ b/nextjs-new_website/src/app/donate/page.tsx
@@ -4,6 +4,25 @@ import Navbar from "@/components/Navbar";
 
 export const revalidate = 30; // ISR: revalidate every 30s
 
+interface DonateSocialLink {
+  platform?: string;
+  url?: string;
+}
+
+interface DonatePageData {
+  title?: string;
+  Image?: {
+    asset?: {
+      url?: string;
+    };
+  };
+  ButtonText?: string;
+  introText?: string;
+  supportingContent?: string;
+  secondaryButtonText?: string;
+  socialLinks?: DonateSocialLink[];
+}
+
 async function getDonatePage() {
   const query = `*[_type == "donatePage"][0]{
     title,
@@ -18,7 +37,7 @@ async function getDonatePage() {
     secondaryButtonText,
     socialLinks
   }`;
-  return await client.fetch(query);
+  return await client.fetch<DonatePageData | null>(query);
 }
 
 export default async function DonatePage() {
@@ -27,6 +46,8 @@ export default async function DonatePage() {
   if (!data) {
     return <div className="p-10 text-center">No donate page content found.</div>;
   }
+
+  const socialLinks = data.socialLinks ?? [];
 
   return (
     <>
@@ -65,9 +86,9 @@ export default async function DonatePage() {
           )}
         </div>
 
-        {data.socialLinks?.length > 0 && (
+        {socialLinks.length > 0 && (
           <div className="flex justify-center gap-6 mt-8">
-            {data.socialLinks.map((link: any, idx: number) => (
+            {socialLinks.map((link, idx) => (
               <a
                 key={idx}
                 href={link.url}

--- a/nextjs-new_website/src/app/homeComponents.tsx
+++ b/nextjs-new_website/src/app/homeComponents.tsx
@@ -2,6 +2,14 @@ import Image from "next/image";
 import { PortableTextComponents } from "@portabletext/react";
 import { urlFor } from "@/sanity/client";
 
+interface ButtonRowItem {
+  _key?: string;
+  href?: string;
+  label?: string;
+  openInNewTab?: boolean;
+  variant?: string;
+}
+
 export const homeComponents: PortableTextComponents = {
   types: {
     // 🖼 IMAGE
@@ -179,7 +187,7 @@ export const homeComponents: PortableTextComponents = {
 
       return (
         <div className="my-10 flex flex-wrap items-center justify-center gap-4">
-          {buttons.map((button: any) => (
+          {buttons.map((button: ButtonRowItem) => (
             <a
               key={button?._key || `${button?.href}-${button?.label}`}
               href={button?.href}

--- a/nextjs-new_website/src/app/programs/IAP/page.tsx
+++ b/nextjs-new_website/src/app/programs/IAP/page.tsx
@@ -41,10 +41,20 @@ interface IapPageData {
 
 }
 
+interface RawIapPageData {
+  title: string
+  heroImage1: ImageAsset
+  heroImage2: ImageAsset
+  heroImage3: ImageAsset
+  heroImage4: ImageAsset
+  body?: StudentBlock[]
+  studentProjectsBody?: StudentBlock[]
+}
+
 
 
 async function getIapPageData(): Promise<IapPageData> {
-  const data = await client.fetch<any>(`
+  const data = await client.fetch<RawIapPageData>(`
     *[_type == "iapPage"][0] {
       title,
       heroImage1 { asset->{url, metadata{dimensions}} },

--- a/nextjs-new_website/src/app/programs/turning_the_tide_of_trauma/page.tsx
+++ b/nextjs-new_website/src/app/programs/turning_the_tide_of_trauma/page.tsx
@@ -9,7 +9,10 @@ interface TtoT {
     title: string;
     mainImage: { asset: { _ref: string } };
     description: string;
-    links: []
+    links: {
+      linkname: string;
+      linkurl: string;
+    }[]
 }
 export const revalidate = 60;
 
@@ -29,7 +32,7 @@ async function getTtoT() {
 //update markdown to incroporate links
 //check for line breaks?
 function readMarkdown(text: string){
-    var toReturn = text;
+    let toReturn = text;
     //  //Blockquote
     toReturn = toReturn.replace(/\>(.+)/g,"<blockquote>$1</blockquote>");
     //Bolden

--- a/nextjs-new_website/src/app/think_round_fine_arts/past_exhibitions/page.tsx
+++ b/nextjs-new_website/src/app/think_round_fine_arts/past_exhibitions/page.tsx
@@ -2,6 +2,7 @@ import { client, urlFor } from "@/sanity/client";
 import Image from "next/image";
 import Link from "next/link";
 import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
 import type { Metadata } from "next";
 
 export const revalidate = 30;

--- a/nextjs-new_website/src/components/Footer.tsx
+++ b/nextjs-new_website/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 const socialLinks = [
   {
@@ -55,10 +56,10 @@ function SocialIcons({ className = "" }: { className?: string }) {
 function NavLinks({ className = "", boardLabel = "Our Board Members" }: { className?: string; boardLabel?: string }) {
   return (
     <nav className={`flex flex-wrap items-center gap-x-6 gap-y-2 text-base font-[100] text-gray-200 ${className}`}>
-      <a href="/mission" className="hover:underline transition-all whitespace-nowrap">Mission</a>
-      <a href="/contact" className="hover:underline transition-all whitespace-nowrap">Contact</a>
-      <a href="/board" className="hover:underline transition-all whitespace-nowrap">{boardLabel}</a>
-      <a href="/map" className="hover:underline transition-all whitespace-nowrap">Map</a>
+      <Link href="/mission" className="hover:underline transition-all whitespace-nowrap">Mission</Link>
+      <Link href="/about/contact_us" className="hover:underline transition-all whitespace-nowrap">Contact</Link>
+      <Link href="/board" className="hover:underline transition-all whitespace-nowrap">{boardLabel}</Link>
+      <Link href="/map" className="hover:underline transition-all whitespace-nowrap">Map</Link>
     </nav>
   );
 }
@@ -144,4 +145,3 @@ export default function Footer() {
     </footer>
   );
 }
-

--- a/nextjs-new_website/src/components/GalleryList.tsx
+++ b/nextjs-new_website/src/components/GalleryList.tsx
@@ -2,11 +2,12 @@ import Link from "next/link";
 import { SanityDocument } from "next-sanity";
 import Image from "next/image";
 import imageUrlBuilder from '@sanity/image-url';
+import type { SanityImageSource } from "@sanity/image-url/lib/types/types";
 import { client } from "@/sanity/client";
 
 const builder = imageUrlBuilder(client);
 
-function urlFor(source: any) {
+function urlFor(source: SanityImageSource) {
   return builder.image(source);
 }
 

--- a/nextjs-new_website/src/sanity/client.ts
+++ b/nextjs-new_website/src/sanity/client.ts
@@ -1,5 +1,6 @@
 import { createClient } from "next-sanity";
 import imageUrlBuilder from "@sanity/image-url";
+import type { SanityImageSource } from "@sanity/image-url/lib/types/types";
 
 export const client = createClient({
   projectId: "s3cfqcyr",
@@ -10,4 +11,4 @@ export const client = createClient({
 
 const builder = imageUrlBuilder(client);
 
-export const urlFor = (source: any) => builder.image(source);
+export const urlFor = (source: SanityImageSource) => builder.image(source);

--- a/studio-new_website/schemaTypes/contactUs.ts
+++ b/studio-new_website/schemaTypes/contactUs.ts
@@ -1,0 +1,62 @@
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
+  name: 'contactUs',
+  title: 'Contact Us',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Page Title',
+      type: 'string',
+      description: 'Main heading for the contact page (e.g., "Contact")',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'contactName',
+      title: 'Contact Name',
+      type: 'string',
+      description: 'Primary contact person (e.g., "Heidi Hardin")',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'aboutCompany',
+      title: 'About Company',
+      type: 'text',
+      description: 'Short description of ThinkRound for the contact page',
+    }),
+    defineField({
+      name: 'address',
+      title: 'Address',
+      type: 'text',
+      description: 'Mailing or office address shown on the contact page',
+    }),
+    defineField({
+      name: 'phone',
+      title: 'Phone Number',
+      type: 'string',
+      description: 'Contact phone number (e.g., "415-771-2198")',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'email',
+      title: 'Email Address',
+      type: 'string',
+      description: 'Contact email address',
+      validation: (rule) => rule.required().email(),
+    }),
+    defineField({
+      name: 'boardSectionTitle',
+      title: 'Board Section Title',
+      type: 'string',
+      description: 'Heading for the board members section (e.g., "Meet our Board of Directors")',
+      validation: (rule) => rule.required(),
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'contactName',
+    },
+  },
+})

--- a/studio-new_website/schemaTypes/index.ts
+++ b/studio-new_website/schemaTypes/index.ts
@@ -16,6 +16,7 @@ import videoFeatureBlock from './homepage/videoFeatureBlock'
 import buttonRow from './homepage/buttonRow'
 import paradiseProject from './paradiseProject'
 import painting from './painting'
+import contactUs from './contactUs'
 
 export const schemaTypes = [
   boardMember,
@@ -36,4 +37,5 @@ export const schemaTypes = [
   buttonRow,
   paradiseProject,
   painting,
+  contactUs,
 ]


### PR DESCRIPTION
- Added Contact Us Sanity schema and registered it
- Added `/about/contact_us` page with company info, address, primary contact, contact form, and board list
- Updated Footer Contact link to `/about/contact_us`
- Fixed build-blocking lint/type/prerender issues


Testing Screenshots:
<img width="1467" height="879" alt="Screenshot 2026-06-21 at 9 06 07 PM" src="https://github.com/user-attachments/assets/91f7fee4-61f9-4649-b301-b531f573d7ee" />
<img width="1468" height="884" alt="Screenshot 2026-06-21 at 9 05 32 PM" src="https://github.com/user-attachments/assets/cc21c52d-97df-413b-ba28-7e8a2c9e193f" />
