### PR TITLE
Fix off-by-one published date on blog post pages

### DIFF
--- a/nextjs-new_website/src/app/blogs/[year]/[month]/[day]/[slug]/page.tsx
+++ b/nextjs-new_website/src/app/blogs/[year]/[month]/[day]/[slug]/page.tsx
@@ -30,6 +30,17 @@ async function getBlog(params: { date: string; slug: string }) {
   return client.fetch<Blog>(query, params);
 }
 
+// publishedAt is a Sanity `date` ("YYYY-MM-DD"); new Date(str) parses it as UTC midnight,
+// so rendering in local time shows the previous day west of UTC. Build a local date instead.
+function formatPublishedDate(publishedAt: string): string {
+  const [year, month, day] = publishedAt.split("-").map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
 export default async function BlogPostPage({
   params,
 }: {
@@ -54,11 +65,7 @@ export default async function BlogPostPage({
         <div className="max-w-3xl mx-auto flex flex-col items-start">
           <div className="text-[11px] font-bold tracking-[0.2em] uppercase text-black mb-6">
             {blog.author} <span className="mx-2 text-gray-300">•</span>{" "}
-            {new Date(blog.publishedAt).toLocaleDateString("en-US", {
-              month: "long",
-              day: "numeric",
-              year: "numeric",
-            })}
+            {formatPublishedDate(blog.publishedAt)}
           </div>
 
           <header className="mb-12 w-full text-left">


### PR DESCRIPTION
This PR proposes a fix for an off-by-one error in the published date shown on blog post pages, where a post's date renders one calendar day earlier than it was stored for visitors in U.S. (and any other west-of-UTC) time zones. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/226. You can sign in with your GitHub ID to claim ownership of the project.

## What was wrong

The blog post page at `nextjs-new_website/src/app/blogs/[year]/[month]/[day]/[slug]/page.tsx` rendered the date with `new Date(blog.publishedAt).toLocaleDateString("en-US", …)`. `publishedAt` comes from a Sanity `date` field, which serializes as a bare `"YYYY-MM-DD"` string; `new Date("YYYY-MM-DD")` is parsed as **UTC midnight**, and `toLocaleDateString` then renders that instant in the local zone, which lands on the previous day anywhere west of UTC. A post published on `2026-08-12` therefore displayed as "August 11, 2026" for U.S. readers.

## The fix

Your `think_round_fine_arts/past_exhibitions` code already handles this correctly — its `formatDateRange` builds the date with `new Date(year, month - 1, day)` — so this change brings the blog page in line with that same pattern by splitting the `year`/`month`/`day` parts and constructing a local date. The edit is confined to a single file and to the date-formatting path only; no other page or behavior changes.

## How to reproduce on the current default branch

```
$ TZ=America/Los_Angeles node -e 'const p="2026-08-12", o={month:"long",day:"numeric",year:"numeric"};
console.log("current:", new Date(p).toLocaleDateString("en-US", o));
const [y,m,d]=p.split("-").map(Number);
console.log("fixed:  ", new Date(y,m-1,d).toLocaleDateString("en-US", o));'
current: August 11, 2026
fixed:   August 12, 2026
```

Under `TZ=UTC` both lines print "August 12, 2026", which confirms the discrepancy is purely the UTC-parse / local-render mismatch rather than anything data-related.

## Verification

I ran the project's own checks before and after the change: `npx tsc --noEmit` and `npm run lint` show no new type or lint errors introduced by this change, and the modified file passes both cleanly. The repository has no test runner, so the deterministic snippet above is included as a check you can replay in a few seconds.

## How this was managed

We imported this repository's issues and pull requests into a live agile board (57 stories, mirroring your history) and used it to track this fix. The board and the specific story for this work are linked below:

- Story: https://eastagiletracker.com/projects/226/stories/90821
- Board: https://eastagiletracker.com/projects/226

![board](https://raw.githubusercontent.com/eastagiletracker/ThinkRound-New-Website/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
