### PR TITLE
Add Current & Upcoming Exhibitions feature

### DIFF
--- a/nextjs-new_website/src/app/think_round_fine_arts/current_upcoming_exhibitions/[slug]/page.tsx
+++ b/nextjs-new_website/src/app/think_round_fine_arts/current_upcoming_exhibitions/[slug]/page.tsx
@@ -1,0 +1,324 @@
+import { client, urlFor } from "@/sanity/client";
+import Link from "next/link";
+import { PortableText, PortableTextBlock } from "next-sanity";
+import Navbar from "@/components/Navbar";
+import ExhibitionGallery from "@/components/ExhibitionGallery";
+import ArtistCard from "@/components/ArtistCard";
+import type { Metadata } from "next";
+
+export const revalidate = 30;
+
+interface Artist {
+  name: string;
+  bio?: string;
+  photo?: {
+    asset: { _ref: string; _type: string };
+  };
+}
+
+interface ArtworkItem {
+  image: {
+    asset: { _ref: string; _type: string };
+    hotspot?: { x: number; y: number };
+  };
+  caption?: string;
+  alt?: string;
+}
+
+interface ExhibitionLink {
+  label: string;
+  url: string;
+}
+
+interface CurrentExhibitionDetail {
+  _id: string;
+  title: string;
+  slug: { current: string };
+  startDate: string;
+  endDate: string;
+  coverImage: {
+    asset: { _ref: string; _type: string };
+    alt?: string;
+  };
+  description?: PortableTextBlock[];
+  artists?: Artist[];
+  artworkGallery?: ArtworkItem[];
+  receptionInfo?: string;
+  links?: ExhibitionLink[];
+  galleryLocation?: string;
+}
+
+async function getExhibition(
+  slug: string,
+): Promise<CurrentExhibitionDetail | null> {
+  return client.fetch<CurrentExhibitionDetail | null>(
+    `*[_type == "currentExhibition" && slug.current == $slug][0]{
+      _id,
+      title,
+      slug,
+      startDate,
+      endDate,
+      coverImage,
+      description,
+      artists,
+      artworkGallery,
+      receptionInfo,
+      links,
+      galleryLocation
+    }`,
+    { slug },
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const exhibition = await getExhibition(slug);
+
+  if (!exhibition) {
+    return { title: "Exhibition Not Found | ThinkRound" };
+  }
+
+  return {
+    title: `${exhibition.title} | Current & Upcoming Exhibitions | ThinkRound`,
+    description: `View details about the "${exhibition.title}" exhibition at ThinkRound.`,
+    openGraph: {
+      title: `${exhibition.title} | ThinkRound`,
+      images: exhibition.coverImage
+        ? [
+            {
+              url: urlFor(exhibition.coverImage)
+                .width(1200)
+                .height(630)
+                .auto("format")
+                .url(),
+              width: 1200,
+              height: 630,
+              alt: exhibition.coverImage.alt || exhibition.title,
+            },
+          ]
+        : [],
+    },
+  };
+}
+
+export async function generateStaticParams() {
+  const exhibitions = await client.fetch<{ slug: string }[]>(
+    `*[_type == "currentExhibition"]{ "slug": slug.current }`,
+  );
+  return exhibitions.map((e) => ({ slug: e.slug }));
+}
+
+const descriptionComponents = {
+  marks: {
+    strong: ({ children }: { children?: React.ReactNode }) => (
+      <strong className="font-bold">{children}</strong>
+    ),
+    em: ({ children }: { children?: React.ReactNode }) => (
+      <em className="italic">{children}</em>
+    ),
+    link: ({
+      value,
+      children,
+    }: {
+      value?: { href: string };
+      children?: React.ReactNode;
+    }) => (
+      <a
+        href={value?.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-blue-600 underline hover:text-blue-800 transition-colors"
+      >
+        {children}
+      </a>
+    ),
+  },
+  block: {
+    normal: ({ children }: { children?: React.ReactNode }) => (
+      <p className="text-lg font-light text-gray-700 mb-4 leading-relaxed">
+        {children}
+      </p>
+    ),
+    h1: ({ children }: { children?: React.ReactNode }) => (
+      <h1 className="text-4xl font-bold text-black mt-8 mb-4">{children}</h1>
+    ),
+    h2: ({ children }: { children?: React.ReactNode }) => (
+      <h2 className="text-3xl font-bold text-black mt-8 mb-4">{children}</h2>
+    ),
+    h3: ({ children }: { children?: React.ReactNode }) => (
+      <h3 className="text-2xl font-bold text-black mt-6 mb-3">{children}</h3>
+    ),
+    h4: ({ children }: { children?: React.ReactNode }) => (
+      <h4 className="text-xl font-bold text-black mt-6 mb-3">{children}</h4>
+    ),
+    h5: ({ children }: { children?: React.ReactNode }) => (
+      <h5 className="text-lg font-bold text-black mt-4 mb-2">{children}</h5>
+    ),
+    h6: ({ children }: { children?: React.ReactNode }) => (
+      <h6 className="text-base font-bold text-black mt-4 mb-2">{children}</h6>
+    ),
+    blockquote: ({ children }: { children?: React.ReactNode }) => (
+      <blockquote className="border-l-4 border-gray-300 pl-4 italic my-4 text-gray-600">
+        {children}
+      </blockquote>
+    ),
+  },
+};
+
+function formatDateRange(startDate: string, endDate: string): string {
+  const [sy, sm, sd] = startDate.split("-").map(Number);
+  const [ey, em, ed] = endDate.split("-").map(Number);
+  const start = new Date(sy, sm - 1, sd);
+  const end = new Date(ey, em - 1, ed);
+  const opts: Intl.DateTimeFormatOptions = {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  };
+  return `${start.toLocaleDateString("en-US", opts)} – ${end.toLocaleDateString("en-US", opts)}`;
+}
+
+export default async function CurrentExhibitionDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const exhibition = await getExhibition(slug);
+
+  if (!exhibition) {
+    return (
+      <>
+        <Navbar />
+        <main className="min-h-screen bg-white text-black p-8 flex flex-col justify-center items-center">
+          <h1 className="text-4xl font-bold mb-4">Exhibition Not Found</h1>
+          <Link
+            href="/think_round_fine_arts/current_upcoming_exhibitions"
+            className="text-blue-600 hover:underline"
+          >
+            Back to Current & Upcoming Exhibitions
+          </Link>
+        </main>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Navbar />
+      <main className="min-h-screen bg-white px-6 py-16">
+        <div className="max-w-4xl mx-auto">
+          <Link
+            href="/think_round_fine_arts/current_upcoming_exhibitions"
+            className="inline-flex items-center text-gray-500 hover:text-black transition-colors mb-8"
+          >
+            <span className="mr-2">&larr;</span> Back to Current & Upcoming
+            Exhibitions
+          </Link>
+
+          <header className="mb-12">
+            <h1 className="text-4xl md:text-5xl font-light uppercase leading-tight tracking-tight text-black">
+              {exhibition.title}
+            </h1>
+            <p className="text-lg text-gray-500 mt-4">
+              {formatDateRange(exhibition.startDate, exhibition.endDate)}
+            </p>
+            {exhibition.galleryLocation && (
+              <p className="text-base text-gray-400 mt-1">
+                {exhibition.galleryLocation}
+              </p>
+            )}
+          </header>
+
+          <ExhibitionGallery
+            images={[
+              {
+                src: urlFor(exhibition.coverImage).width(1200).url(),
+                thumbSrc: urlFor(exhibition.coverImage)
+                  .width(160)
+                  .height(160)
+                  .url(),
+                blurDataURL: urlFor(exhibition.coverImage)
+                  .width(20)
+                  .blur(10)
+                  .url(),
+                alt:
+                  exhibition.coverImage.alt || `${exhibition.title} exhibition`,
+              },
+              ...(exhibition.artworkGallery || []).map((artwork, index) => ({
+                src: urlFor(artwork.image).width(1200).url(),
+                thumbSrc: urlFor(artwork.image).width(160).height(160).url(),
+                blurDataURL: urlFor(artwork.image).width(20).blur(10).url(),
+                alt: artwork.alt || artwork.caption || `Artwork ${index + 1}`,
+                caption: artwork.caption,
+              })),
+            ]}
+          />
+
+          {exhibition.receptionInfo && (
+            <div className="bg-gray-50 rounded-lg p-6 mb-12 border border-gray-200">
+              <h2 className="text-sm font-bold tracking-[0.2em] uppercase text-gray-400 mb-2">
+                Reception & Event Information
+              </h2>
+              <p className="text-lg text-gray-700 whitespace-pre-line">
+                {exhibition.receptionInfo}
+              </p>
+            </div>
+          )}
+
+          {exhibition.links && exhibition.links.length > 0 && (
+            <div className="flex flex-wrap gap-4 mb-12">
+              {exhibition.links.map((link, index) => (
+                <a
+                  key={index}
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 px-6 py-3 border-2 border-gray-800 text-gray-800 font-semibold rounded-full hover:bg-gray-800 hover:text-white transition-colors"
+                >
+                  {link.label}
+                  <span>&rarr;</span>
+                </a>
+              ))}
+            </div>
+          )}
+
+          {exhibition.artists && exhibition.artists.length > 0 && (
+            <section className="mb-12">
+              <h2 className="text-sm font-bold tracking-[0.2em] uppercase text-gray-400 mb-4">
+                Featured Artists
+              </h2>
+              <div className="flex gap-4 overflow-x-auto pb-3 scrollbar-hide">
+                {exhibition.artists.map((artist, index) => (
+                  <ArtistCard
+                    key={index}
+                    name={artist.name}
+                    bio={artist.bio}
+                    photoUrl={
+                      artist.photo
+                        ? urlFor(artist.photo).width(96).height(96).url()
+                        : undefined
+                    }
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {exhibition.description && (
+            <section className="mb-16">
+              <PortableText
+                value={exhibition.description}
+                components={descriptionComponents}
+              />
+            </section>
+          )}
+        </div>
+      </main>
+    </>
+  );
+}

--- a/nextjs-new_website/src/app/think_round_fine_arts/current_upcoming_exhibitions/page.tsx
+++ b/nextjs-new_website/src/app/think_round_fine_arts/current_upcoming_exhibitions/page.tsx
@@ -1,0 +1,135 @@
+import { client, urlFor } from "@/sanity/client";
+import Image from "next/image";
+import Link from "next/link";
+import Navbar from "@/components/Navbar";
+import type { Metadata } from "next";
+
+export const revalidate = 30;
+
+export const metadata: Metadata = {
+  title: "Current & Upcoming Exhibitions | ThinkRound",
+  description:
+    "Browse ThinkRound's current and upcoming fine art exhibitions featuring diverse artists and mediums.",
+};
+
+interface CurrentExhibitionCard {
+  _id: string;
+  title: string;
+  cardTitle?: string;
+  slug: { _type: "slug"; current: string };
+  startDate: string;
+  endDate: string;
+  coverImage: {
+    asset: { _ref: string; _type: string };
+    alt?: string;
+    hotspot?: { x: number; y: number };
+  };
+}
+
+async function getExhibitions(): Promise<CurrentExhibitionCard[]> {
+  return client.fetch<CurrentExhibitionCard[]>(
+    `*[_type == "currentExhibition"] | order(startDate asc) {
+      _id,
+      title,
+      cardTitle,
+      slug,
+      startDate,
+      endDate,
+      coverImage
+    }`,
+  );
+}
+
+function formatDateRange(startDate: string, endDate: string): string {
+  const [sy, sm, sd] = startDate.split("-").map(Number);
+  const [ey, em, ed] = endDate.split("-").map(Number);
+  const start = new Date(sy, sm - 1, sd);
+  const end = new Date(ey, em - 1, ed);
+  const startStr = start.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+  const endStr = end.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  return `${startStr} – ${endStr}`;
+}
+
+function getYear(dateStr: string): string {
+  const [y] = dateStr.split("-");
+  return y;
+}
+
+export default async function CurrentExhibitionsPage() {
+  const exhibitions = await getExhibitions();
+
+  if (!exhibitions || exhibitions.length === 0) {
+    return (
+      <>
+        <Navbar />
+        <main className="min-h-screen bg-white text-black p-8 flex justify-center items-center">
+          <h1 className="text-4xl font-bold">No current exhibitions found.</h1>
+        </main>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Navbar />
+      <main className="min-h-screen bg-white px-6 py-16">
+        <div className="max-w-[1400px] mx-auto">
+          <h1 className="text-4xl md:text-5xl font-light uppercase leading-tight tracking-tight text-black text-center mb-16">
+            Current & Upcoming Exhibitions
+          </h1>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
+            {exhibitions.map((exhibition, index) => (
+              <Link
+                key={exhibition._id}
+                href={`/think_round_fine_arts/current_upcoming_exhibitions/${exhibition.slug.current}`}
+                className="group block overflow-hidden rounded-lg shadow-md hover:shadow-xl transition-shadow duration-300"
+              >
+                <div className="relative aspect-[4/3] bg-white overflow-hidden">
+                  <Image
+                    src={urlFor(exhibition.coverImage).width(1200).url()}
+                    alt={
+                      exhibition.coverImage.alt ||
+                      `${exhibition.title} exhibition cover`
+                    }
+                    fill
+                    className="object-cover transition-transform duration-500 group-hover:scale-105"
+                    {...(index < 4
+                      ? { priority: true }
+                      : {
+                          placeholder: "blur" as const,
+                          blurDataURL: urlFor(exhibition.coverImage)
+                            .width(20)
+                            .blur(10)
+                            .url(),
+                        })}
+                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, (max-width: 1280px) 33vw, 25vw"
+                  />
+                </div>
+
+                <div className="px-4 py-3 bg-white">
+                  <h2 className="text-sm font-semibold text-black group-hover:text-gray-600 transition-colors">
+                    {exhibition.cardTitle ?? exhibition.title}{" "}
+                    <span className="text-gray-400 font-normal">
+                      ({getYear(exhibition.startDate)})
+                    </span>
+                  </h2>
+                  <p className="text-xs text-gray-500 mt-0.5">
+                    {formatDateRange(exhibition.startDate, exhibition.endDate)}
+                  </p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/nextjs-new_website/src/components/Navbar.tsx
+++ b/nextjs-new_website/src/components/Navbar.tsx
@@ -53,7 +53,7 @@ export default function Navbar() {
         },
         {
           name: "CURRENT & UPCOMING EXHIBITIONS",
-          href: "/about/current_upcoming_exhibitions",
+          href: "/think_round_fine_arts/current_upcoming_exhibitions",
         },
         {
           name: "PAST EXHIBITIONS",

--- a/studio-new_website/schemaTypes/currentExhibition.ts
+++ b/studio-new_website/schemaTypes/currentExhibition.ts
@@ -1,0 +1,233 @@
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
+  name: 'currentExhibition',
+  title: 'Current & Upcoming Exhibition',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      description: 'Exhibition name, e.g. "Pieced Together"',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'cardTitle',
+      title: 'Card Title (optional)',
+      type: 'string',
+      description:
+        'Short title shown on the listing card. If left blank, the main Title is used. (Useful when the full title is too long for a card)',
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: {
+        source: (doc: Record<string, unknown>) =>
+          (doc.cardTitle as string) || (doc.title as string) || '',
+      },
+      description: 'URL-friendly identifier, auto-generated from title',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'startDate',
+      title: 'Start Date',
+      type: 'date',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'endDate',
+      title: 'End Date',
+      type: 'date',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'galleryLocation',
+      title: 'Gallery Location (optional)',
+      type: 'string',
+      description: 'e.g. "ThinkRound Gallery, 2140 Bush Street, SF"',
+    }),
+    defineField({
+      name: 'coverImage',
+      title: 'Cover Image',
+      type: 'image',
+      options: {hotspot: true},
+      description:
+        'Main image shown on the listing page grid card. Images are automatically optimized and served in AVIF/WebP format to supported browsers.',
+      fields: [
+        {
+          name: 'alt',
+          type: 'string',
+          title: 'Alternative Text (optional)',
+          description: 'Important for SEO and accessibility.',
+        },
+      ],
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'artworkGallery',
+      title: 'Artwork Gallery',
+      type: 'array',
+      description:
+        'Artwork images displayed in the exhibition. Images are automatically optimized and served in AVIF/WebP format to supported browsers.',
+      of: [
+        {
+          type: 'object',
+          fields: [
+            {
+              name: 'image',
+              title: 'Artwork Image',
+              type: 'image',
+              options: {hotspot: true},
+              validation: (Rule) => Rule.required(),
+            },
+            {
+              name: 'caption',
+              title: 'Caption (optional)',
+              type: 'string',
+              description: 'e.g. "Artist Name - Title, Year, Medium"',
+            },
+            {
+              name: 'alt',
+              title: 'Alt Text (optional)',
+              type: 'string',
+              description: 'Describes the image for screen readers. If empty, caption is used.',
+            },
+          ],
+          preview: {
+            select: {
+              title: 'caption',
+              media: 'image',
+            },
+          },
+        },
+      ],
+    }),
+    defineField({
+      name: 'receptionInfo',
+      title: 'Reception and Other Time-Sensitive Information (optional)',
+      type: 'text',
+      rows: 4,
+      description: 'Include opening reception date/time, artist talk time, gallery hours, etc.',
+    }),
+    defineField({
+      name: 'links',
+      title: 'Related Links (optional)',
+      type: 'array',
+      description:
+        'Add links to opening reception video, artist interviews, or other related content.',
+      of: [
+        {
+          type: 'object',
+          fields: [
+            {
+              name: 'label',
+              title: 'Link Label',
+              type: 'string',
+              description: 'e.g. "Watch the Opening Reception", "Watch the Artist Interviews"',
+              validation: (Rule) => Rule.required(),
+            },
+            {
+              name: 'url',
+              title: 'URL',
+              type: 'url',
+              validation: (Rule) => Rule.required(),
+            },
+          ],
+          preview: {
+            select: {
+              title: 'label',
+              subtitle: 'url',
+            },
+          },
+        },
+      ],
+    }),
+    defineField({
+      name: 'artists',
+      title: 'Artists',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          fields: [
+            {
+              name: 'name',
+              title: 'Name (required)',
+              type: 'string',
+              validation: (Rule) => Rule.required(),
+            },
+            {
+              name: 'bio',
+              title: 'Bio (optional)',
+              type: 'text',
+              rows: 3,
+            },
+            {
+              name: 'photo',
+              title: 'Photo (optional)',
+              type: 'image',
+              options: {hotspot: true},
+              description:
+                'Images are automatically optimized and served in AVIF/WebP format to supported browsers.',
+            },
+          ],
+          preview: {
+            select: {
+              title: 'name',
+              media: 'photo',
+            },
+          },
+        },
+      ],
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [
+            {title: 'Normal', value: 'normal'},
+            {title: 'H1 Heading', value: 'h1'},
+            {title: 'H2 Heading', value: 'h2'},
+            {title: 'H3 Heading', value: 'h3'},
+            {title: 'H4 Heading', value: 'h4'},
+            {title: 'H5 Heading', value: 'h5'},
+            {title: 'H6 Heading', value: 'h6'},
+            {title: 'Quote', value: 'blockquote'},
+          ],
+        },
+      ],
+    }),
+    defineField({
+      name: 'order',
+      title: 'Display Order (optional)',
+      type: 'number',
+      description: 'Lower numbers appear first. If not set, sorted by startDate ascending.',
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'startDate',
+      media: 'coverImage',
+    },
+    prepare({title, subtitle, media}) {
+      return {
+        title,
+        subtitle: subtitle ? new Date(subtitle).getFullYear().toString() : '',
+        media,
+      }
+    },
+  },
+  orderings: [
+    {
+      title: 'Start Date, Soonest',
+      name: 'startDateAsc',
+      by: [{field: 'startDate', direction: 'asc'}],
+    },
+  ],
+})

--- a/studio-new_website/schemaTypes/index.ts
+++ b/studio-new_website/schemaTypes/index.ts
@@ -7,6 +7,7 @@ import {streamOfConsciousness} from './streamOfConsciousness'
 import donatePage from './donatePage'
 import blogs from './blogs'
 import pastExhibition from './pastExhibition'
+import currentExhibition from './currentExhibition'
 import iapPage from './iap'
 import classes from './classes'
 import turningTheTide from './turningTheTideOfTrauma'
@@ -30,6 +31,7 @@ export const schemaTypes = [
   donatePage,
   blogs,
   pastExhibition,
+  currentExhibition,
   iapPage,
   classes,
   turningTheTide,


### PR DESCRIPTION
## Summary
Adds a "Current & Upcoming Exhibitions" feature to the site.

## Changes
- New `currentExhibition` schema in Sanity Studio
- New Next.js listing page for exhibitions
- New Next.js detail page for individual exhibitions
- Minor fixes to navbar/JSX issues encountered during integration

## Notes
- Tested locally against the `test`/`production` dataset