### PR TITLE
Fix CMP navbar route

### DIFF
--- a/nextjs-new_website/src/components/Navbar.tsx
+++ b/nextjs-new_website/src/components/Navbar.tsx
@@ -42,7 +42,7 @@ export default function Navbar() {
         },
         {
           name: "CHILDREN'S MURAL PROGRAM",
-          href: "nextjs-new_website\\src\\app\\programs\\children_mural_program\\page.tsx",
+          href: "/programs/children_mural_program",
         },  
 
       ],


### PR DESCRIPTION
## Summary

Fixed the Children's Mural Program Navbar link.

### Change

- Updated the CMP Navbar href to `/programs/children_mural_program`

### Testing

- Verified locally that the Navbar link correctly opens the CMP page.